### PR TITLE
Exclude REF_AREA from geojson output

### DIFF
--- a/config_data.yml
+++ b/config_data.yml
@@ -113,6 +113,8 @@ map_layers:
     id_property: ADM1_PCODE
     output_subfolder: regions
     filename_prefix: indicator_
+    exclude_columns:
+      - REF_AREA
 
 # Documentation settings
 # ----------------------


### PR DESCRIPTION
This change should prevent the "REF_AREA" label from appearing on the map:

![image](https://github.com/user-attachments/assets/38ac8b74-15e6-4f06-8894-983135f63626)
